### PR TITLE
Fix hybrid RRF scoring direction

### DIFF
--- a/src/chroma_service.py
+++ b/src/chroma_service.py
@@ -258,7 +258,7 @@ class ChromaService:
                 limit=rank_limit,
                 return_rank=True,
             )
-            dense_rrf = Val(dense_weight) / (Val(rrf_k) + dense_knn)
+            dense_rrf = Val(-dense_weight) / (Val(rrf_k) + dense_knn)
             rank_expression = dense_rrf
 
         if sparse_embedding and sparse_weight > 0:
@@ -268,7 +268,7 @@ class ChromaService:
                 limit=rank_limit,
                 return_rank=True,
             )
-            sparse_rrf = Val(sparse_weight) / (Val(rrf_k) + sparse_knn)
+            sparse_rrf = Val(-sparse_weight) / (Val(rrf_k) + sparse_knn)
             rank_expression = (
                 sparse_rrf if rank_expression is None else rank_expression + sparse_rrf
             )


### PR DESCRIPTION
## Summary
- negate the dense and sparse reciprocal rank fusion contributions so that higher quality matches sort to the top

## Testing
- make check

------
https://chatgpt.com/codex/tasks/task_e_68d35da640dc832e9e8124d47402dcff