### PR TITLE
Rename search MCP tool to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Running locally requires credentials for external services:
 
 - `get_post(slug)`: Get a single blog post by slug
 - `list_posts(sort_by, page, limit)`: List posts with pagination
-- `search_posts(query, limit)`: Semantic search across posts
+- `search(query, limit)`: Semantic search across posts
 
 ## API Endpoints
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -108,8 +108,8 @@ async def list_posts(
     }
 
 
-@mcp.tool()
-async def search_posts(
+@mcp.tool(name="search")
+async def search(
     query: str,
     limit: int = 10,
 ) -> dict[str, Any]:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -98,7 +98,7 @@ class TestMCPTools:
 
     @pytest.mark.asyncio
     @patch("src.mcp_server.get_chroma_service")
-    async def test_search_posts(self, mock_get_service):
+    async def test_search_tool(self, mock_get_service):
         mock_service = AsyncMock()
         mock_get_service.return_value = mock_service
 
@@ -117,8 +117,8 @@ class TestMCPTools:
         mock_service.search.return_value = test_results
 
         tools = await mcp.get_tools()
-        search_posts_func = tools["search_posts"].fn
-        result = await search_posts_func(query="test query", limit=5)
+        search_func = tools["search"].fn
+        result = await search_func(query="test query", limit=5)
 
         assert "results" in result
         assert len(result["results"]) == 1


### PR DESCRIPTION
## Summary
- rename the MCP search tool to use the canonical `search` name
- update tests and documentation to reflect the new tool identifier

## Testing
- uv run pytest tests/test_mcp_tools.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68d60906e5e8832eb8a30f23ba0110eb