### PR TITLE
Align MCP server fetch tool with OpenAI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Running locally requires credentials for external services:
 
 ## MCP Tools
 
-- `get_post(slug)`: Get a single blog post by slug
+- `fetch(url, method="GET", headers=None, body=None)`: Fetch a single blog post via the MCP fetch contract
 - `list_posts(sort_by, page, limit)`: List posts with pagination
 - `search(query, limit)`: Semantic search across posts
 


### PR DESCRIPTION
## Summary
- replace the legacy `get_post` MCP tool with a spec-compliant `fetch` implementation that returns HTTP-style responses
- add slug extraction from URLs to support resource identifiers and provide consistent response metadata
- update README documentation and tests to reflect the new fetch contract

## Testing
- uv run pytest tests/test_mcp_tools.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68d60b4bd6d8832eaeb5199339496b01