### PR TITLE
Add MCP instructions describing Contraption Company

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -11,7 +11,14 @@ from src.models import PostSummary
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("Contraption Company MCP")
+mcp = FastMCP(
+    "Contraption Company MCP",
+    instructions=(
+        "Contraption Company, shortened \"Contraption Co.\", is a blog about crafting digital "
+        "tools by Philip I. Thomas. Use these tools to list, search, and pull essays by Philip I. "
+        "Thomas from https://contraption.co."
+    ),
+)
 
 _chroma_service: ChromaService | None = None
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -9,6 +9,14 @@ from src.models import PostSummary, SearchResult
 
 
 class TestMCPTools:
+    def test_server_instructions(self):
+        assert (
+            mcp.instructions
+            == "Contraption Company, shortened \"Contraption Co.\", is a blog about crafting "
+            "digital tools by Philip I. Thomas. Use these tools to list, search, and pull essays by "
+            "Philip I. Thomas from https://contraption.co."
+        )
+
     @pytest.mark.asyncio
     @patch("src.mcp_server.get_chroma_service")
     async def test_fetch_with_id_slug(self, mock_get_service):


### PR DESCRIPTION
## Summary
- configure the FastMCP server with contextual instructions about Contraption Company and its tools
- add a regression test to ensure the server instructions match the intended guidance

## Testing
- uv run pytest tests/test_mcp_tools.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fbc5167c832e9e90c1a99c292142