### PR TITLE
Document ChatGPT connector setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Contraption Company MCP is available as a hosted MCP server with no authenticati
 <details>
 <summary><b>Cursor</b></summary>
 
-Use the deep link to install directly in Cursor: [Install Contraption Company MCP](https://cursor.com/docs/context/mcp/install-links).
+Use the deep link to install directly in Cursor: [Install Contraption Company MCP](cursor://anysphere.cursor-deeplink/mcp/install?name=contraption-company&config=eyJ1cmwiOiJodHRwczovL21jcC5jb250cmFwdGlvbi5jbyJ9).
 
-Create or edit `~/.cursor/mcp.json`:
+Or, create or edit `~/.cursor/mcp.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Contraption Company MCP is available as a hosted MCP server with no authenticati
 <details>
 <summary><b>Cursor</b></summary>
 
+Use the deep link to install directly in Cursor: [Install Contraption Company MCP](https://cursor.com/docs/context/mcp/install-links).
+
 Create or edit `~/.cursor/mcp.json`:
 
 ```json
@@ -26,6 +28,16 @@ Create or edit `~/.cursor/mcp.json`:
   }
 }
 ```
+
+</details>
+
+<details>
+<summary><b>ChatGPT</b></summary>
+
+1. Open **Settings → Connectors**.
+2. Click **Create new connector**.
+3. Set **MCP Server URL** to `https://mcp.contraption.co`.
+4. Leave authentication blank and save.
 
 </details>
 


### PR DESCRIPTION
## Summary
- link to Cursor deep install instructions for the hosted MCP server
- document how to add the Contraption Company MCP as a ChatGPT connector

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d7121b7ac0832ebb92d92d3a98af8a