### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for [Contraption Company](https://contraption.co) essay, built on [Chroma Cloud](https://trychroma.com).
 
+<a href="https://glama.ai/mcp/servers/@contraptionco/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@contraptionco/mcp/badge" alt="Contraption Company MCP server" />
+</a>
+
 ## How to Install
 
 Contraption Company MCP is available as a hosted MCP server with no authentication.


### PR DESCRIPTION
This PR adds a badge for the [Contraption Company MCP](https://glama.ai/mcp/servers/@contraptionco/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@contraptionco/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@contraptionco/mcp/badge" alt="Contraption Company MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.