### PR TITLE
Fix query logging visibility and add debug endpoints

### DIFF
--- a/src/chroma_service.py
+++ b/src/chroma_service.py
@@ -567,7 +567,7 @@ class ChromaService:
         try:
             await asyncio.to_thread(self._log_query_sync, query, timestamp, top_match)
         except Exception as exc:  # pragma: no cover - non-blocking logging
-            logger.warning("Failed to log query asynchronously: %s", exc)
+            logger.error("Failed to log query asynchronously: %s", exc, exc_info=True)
 
     def _log_query_sync(
         self,
@@ -598,7 +598,7 @@ class ChromaService:
                 metadatas=[metadata],
             )
         except Exception as exc:  # pragma: no cover - best-effort logging
-            logger.warning("Failed to log query in Chroma: %s", exc)
+            logger.error("Failed to log query '%s' to Chroma: %s", query[:50], exc, exc_info=True)
         finally:
             query_embedding_service.close()
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -91,14 +91,16 @@ async def debug_query_log_test(
 ) -> dict[str, Any]:
     """Test query logging to verify it's working."""
     import time
+
     chroma_service = await get_chroma_service()
     timestamp = int(time.time())
     top_match = {"post_id": "test", "post_url": "https://contraption.co/test"}
-    
+
     try:
         await chroma_service.log_query(query, top_match)
         # Give the background task a moment to complete
         import asyncio
+
         await asyncio.sleep(1)
         return {
             "status": "ok",
@@ -125,11 +127,13 @@ async def debug_query_log_stats() -> dict[str, Any]:
         if recent.get("documents"):
             for i, doc in enumerate(recent["documents"]):
                 metadata = recent["metadatas"][i] if recent.get("metadatas") else {}
-                recent_queries.append({
-                    "query": doc,
-                    "timestamp": metadata.get("query_ts"),
-                    "top_match_url": metadata.get("top_match_url"),
-                })
+                recent_queries.append(
+                    {
+                        "query": doc,
+                        "timestamp": metadata.get("query_ts"),
+                        "top_match_url": metadata.get("top_match_url"),
+                    }
+                )
         return {
             "status": "ok",
             "total_logged_queries": count,
@@ -138,7 +142,7 @@ async def debug_query_log_stats() -> dict[str, Any]:
         }
     except Exception as e:
         return {
-            "status": "error", 
+            "status": "error",
             "message": str(e),
         }
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -94,7 +94,10 @@ async def debug_query_log_test(
 
     chroma_service = await get_chroma_service()
     timestamp = int(time.time())
-    top_match = {"post_id": "test", "post_url": "https://contraption.co/test"}
+    top_match: dict[str, str | None] = {
+        "post_id": "test",
+        "post_url": "https://contraption.co/test",
+    }
 
     try:
         await chroma_service.log_query(query, top_match)
@@ -124,16 +127,17 @@ async def debug_query_log_stats() -> dict[str, Any]:
         # Get recent queries
         recent = chroma_service.query_collection.get(limit=10)
         recent_queries = []
-        if recent.get("documents"):
-            for i, doc in enumerate(recent["documents"]):
-                metadata = recent["metadatas"][i] if recent.get("metadatas") else {}
-                recent_queries.append(
-                    {
-                        "query": doc,
-                        "timestamp": metadata.get("query_ts"),
-                        "top_match_url": metadata.get("top_match_url"),
-                    }
-                )
+        documents = recent.get("documents") or []
+        metadatas = recent.get("metadatas") or []
+        for i, doc in enumerate(documents):
+            metadata = metadatas[i] if i < len(metadatas) and metadatas[i] else {}
+            recent_queries.append(
+                {
+                    "query": doc,
+                    "timestamp": metadata.get("query_ts") if metadata else None,
+                    "top_match_url": metadata.get("top_match_url") if metadata else None,
+                }
+            )
         return {
             "status": "ok",
             "total_logged_queries": count,


### PR DESCRIPTION
## Problem
Query logging failures were being silently swallowed as warnings, making it hard to diagnose why searches weren't being logged to Chroma.

## Changes
1. **Upgraded log level**: Changed `logger.warning` to `logger.error` with `exc_info=True` so failures show full stack traces in error logs
2. **Added debug endpoints**:
   - `GET /debug/query-log-test?query=...` - Test logging a query and verify it works
   - `GET /debug/query-log-stats` - Check total logged queries and see recent ones

## How to diagnose
After deploying, visit:
- `https://mcp.contraption.co/debug/query-log-stats` to see if any queries have been logged
- `https://mcp.contraption.co/debug/query-log-test?query=hello` to test logging a new query

If logging is failing, check the error logs for stack traces.